### PR TITLE
Update Get-NSXTRouteTable to account for SDDC version and API change

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -32,6 +32,7 @@ Function Connect-NSXTProxy {
         $sddc = $sddcService.get($orgId,$sddcId)
         if($sddc.resource_config.nsxt) {
             $nsxtProxyURL = $sddc.resource_config.nsx_api_public_endpoint_url
+            $sddcVersion = $sddc.resource_config.sddc_manifest.vmc_internal_version
         } else {
             Write-Host -ForegroundColor Red "This is not an NSX-T based SDDC"
             break
@@ -1792,8 +1793,14 @@ Function Get-NSXTRouteTable {
 
     If (-Not $global:nsxtProxyConnection) { Write-error "No NSX-T Proxy Connection found, please use Connect-NSXTProxy" } Else {
         $method = "GET"
-        $routeTableURL = $global:nsxtProxyConnection.Server + "/policy/api/v1/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/sites/default/enforcement-points/vmc-enforcementpoint"
-
+        
+        # Check for SDDC version and account for API changes in NSX-T 2.5 introduced from VMC M9
+        if ([int]$global:nsxtProxyConnection.sddcVersion.split(".")[1] -ge 9){
+            $routeTableURL = $global:nsxtProxyConnection.Server + "/policy/api/v1/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/sites/default/enforcement-points/vmc-enforcementpoint"
+        }else{
+            $routeTableURL = $global:nsxtProxyConnection.Server + "/policy/api/v1/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/deployment-zones/default/enforcement-points/vmc-enforcementpoint"
+        }
+        
         if($RouteSource) {
             $routeTableURL = $routeTableURL + "&route_source=$RouteSource"
         }


### PR DESCRIPTION
Updated Connect-NSXTProxy to capture SDDC version, in order to allow support for multiple API versions.

Updated Get-NSXTRouteTable to check SDDC version and alter enforcement point URL to support NSX-T API differences pre/post VMC M9.
