### PR TITLE
Create new Get-NSXTSegmentStatsbyT1 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 PowerShell Module to interact with the NSX-T Policy API in VMware Cloud on AWS.
 
 In addition to the built-in help for each function, you can he following blog posts includes additional regarding the functions:
+
 * [NSX-T Policy PowerShell Community Module for VMC](https://www.virtuallyghetto.com/2018/09/nsx-t-policy-powershell-community-module-for-vmc.html)
 * [Getting started with the new NSX-T Policy API in VMC](https://www.virtuallyghetto.com/2018/09/getting-started-with-the-new-nsx-t-policy-api-in-vmc.html)
 * [Which NSX-T Policy APIs are used in the NSX-T UI in VMC?](https://www.virtuallyghetto.com/2019/02/which-nsx-t-policy-apis-are-used-in-the-nsx-t-ui-in-vmc.html)
@@ -14,6 +15,7 @@ In addition to the built-in help for each function, you can he following blog po
 * [Managing Distributed Firewall Rules in VMC using PowerShell & NSX-T Policy API](https://www.virtuallyghetto.com/2019/01/managing-distributed-firewall-rules-in-vmc-using-powershell-nsx-t-policy-api.html)
 
 ## Prerequisites
+
 * [PowerCLI 12.0](https://code.vmware.com/web/tool/12.0.0/vmware-powercli) or newer
 * VMware Cloud on AWS scoped [Refresh Token](https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-E2A3B1C1-E9AD-4B00-A6B6-88D31FCDDF7C.html)
 
@@ -45,6 +47,7 @@ In addition to the built-in help for each function, you can he following blog po
 * Get-NSXTT0Stats
 * Get-NSXTVM
 * Get-NSXTVifPerHost
+* Get-NSXTSegmentStatsbyT1
 * New-NSXTDistFirewall
 * New-NSXTDistFirewallSection
 * New-NSXTFirewall

--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.5'
+ModuleVersion = '1.0.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -38,7 +38,7 @@ PowerShellVersion = '6.0'
 RequiredModules = @('VMware.VimAutomation.Vmc')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Connect-NSXTProxy','Get-NSXTSegment','New-NSXTSegment','Set-NSXTSegment','Remove-NSXTSegment','Get-NSXTFirewall','New-NSXTFirewall','Remove-NSXTFirewall','Get-NSXTGroup','New-NSXTGroup','Remove-NSXTGroup','Get-NSXTServiceDefinition','Remove-NSXTServiceDefinition','New-NSXTServiceDefinition','New-NSXTDistFirewallSection','Get-NSXTDistFirewallSection','Remove-NSXTDistFirewallSection','Get-NSXTDistFirewall','New-NSXTDistFirewall','Remove-NSXTDistFirewall','Get-NSXTRouteTable','Get-NSXTOverviewInfo','Get-NSXTInfraScope','Get-NSXTInfraGroup','New-NSXTRouteBasedVPN','Get-NSXTRouteBasedVPN','Remove-NSXTRouteBasedVPN','New-NSXTPolicyBasedVPN','Get-NSXTPolicyBasedVPN','Remove-NSXTPolicyBasedVPN','Get-NSXTDNS','Set-NSXTDNS','Get-NSXTPublicIP','New-NSXTPublicIP','Remove-NSXTPublicIP','Get-NSXTNatRule','New-NSXTNatRule','Remove-NSXTNatRule','Get-NSXTT0Stats','Get-NSXTLinkedVpc','Get-NSXTL2VPN','Get-NSXTPortMirror','Get-NSXTIPFIXCollector','Get-NSXTDirectConnectVIF','Get-NSXTVifPerHost','Get-NSXTVM','Get-NSXTSegmentPort','Get-NSXTGroupMember'
+FunctionsToExport = 'Connect-NSXTProxy','Get-NSXTSegment','New-NSXTSegment','Set-NSXTSegment','Remove-NSXTSegment','Get-NSXTFirewall','New-NSXTFirewall','Remove-NSXTFirewall','Get-NSXTGroup','New-NSXTGroup','Remove-NSXTGroup','Get-NSXTServiceDefinition','Remove-NSXTServiceDefinition','New-NSXTServiceDefinition','New-NSXTDistFirewallSection','Get-NSXTDistFirewallSection','Remove-NSXTDistFirewallSection','Get-NSXTDistFirewall','New-NSXTDistFirewall','Remove-NSXTDistFirewall','Get-NSXTRouteTable','Get-NSXTOverviewInfo','Get-NSXTInfraScope','Get-NSXTInfraGroup','New-NSXTRouteBasedVPN','Get-NSXTRouteBasedVPN','Remove-NSXTRouteBasedVPN','New-NSXTPolicyBasedVPN','Get-NSXTPolicyBasedVPN','Remove-NSXTPolicyBasedVPN','Get-NSXTDNS','Set-NSXTDNS','Get-NSXTPublicIP','New-NSXTPublicIP','Remove-NSXTPublicIP','Get-NSXTNatRule','New-NSXTNatRule','Remove-NSXTNatRule','Get-NSXTT0Stats','Get-NSXTLinkedVpc','Get-NSXTL2VPN','Get-NSXTPortMirror','Get-NSXTIPFIXCollector','Get-NSXTDirectConnectVIF','Get-NSXTVifPerHost','Get-NSXTVM','Get-NSXTSegmentPort','Get-NSXTGroupMember','Get-NSXTSegmentStatsbyT1'
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
 


### PR DESCRIPTION
New function that retrieves all segments based on a Tier-1 Gateway name, and sum all segments statistics.

<img width="1189" alt="Screenshot 2021-03-24 at 15 08 22" src="https://user-images.githubusercontent.com/10382023/112324174-c90be780-8cb2-11eb-866e-37b52a80758c.png">

<img width="1189" alt="Screenshot 2021-03-24 at 15 10 43" src="https://user-images.githubusercontent.com/10382023/112324458-1be59f00-8cb3-11eb-858a-804eadba0fb0.png">

It's not perfect as it accounts for all traffic (East-West and North-South), but it will be helpful for CDS use cases. I plan to update it later this year to use a new NSX-T Policy API that will be introduced in a future VMC version (which will only account for North-South traffic).
