### PR TITLE
Fixed "Get-NSXTRouteTable" (updated enforcement endpoint)

### DIFF
--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -1803,7 +1803,7 @@ Function Get-NSXTRouteTable {
         if ([int]$global:nsxtProxyConnection.sddcVersion.split(".")[1] -ge 9){
             $routeTableURL = $global:nsxtProxyConnection.Server + "/policy/api/v1/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/sites/default/enforcement-points/vmc-enforcementpoint"
         }else{
-            $routeTableURL = $global:nsxtProxyConnection.Server + "/policy/api/v1/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/deployment-zones/default/enforcement-points/vmc-enforcementpoint"
+            $routeTableURL = $global:nsxtProxyConnection.Server + "/policy/api/v1/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/tier-0s/vmc/routing-table?enforcement_point_path=/infra/sites/default/enforcement-points/vmc-enforcementpoint"
         }
         
         if($RouteSource) {


### PR DESCRIPTION
Hi, as in the bash i updated this to point to the new enforcement endpoint. When updating this the function "Get-NSXTRouteTable" is working again with VMC.