### PR TITLE
Add pagination to Get-NSXTGroup

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.9'
+ModuleVersion = '1.0.10'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -95,7 +95,7 @@ Function Get-NSXTSegment {
 
         try {
             if(!$SuppressConsoleOutput) {
-                Write-Host "Retrievig NSX-T Segments ..."
+                Write-Host "Retrieving NSX-T Segments ..."
             }
             if($PSVersionTable.PSEdition -eq "Core") {
                 $requests = Invoke-WebRequest -Uri $segmentsURL -Method $method -Headers $global:nsxtProxyConnection.headers -SkipCertificateCheck


### PR DESCRIPTION
Closes #7 

Modeled code on existing pagination in Get-NSXTSegment.

Tested by deploying > 1K CGW rules into an SDDC. Successfully retrieved groups filtered by name, successfully retrieved all > 1K+ groups .