### PR TITLE
Fixed Write-Error for Remove-NSXTFirewall and Remove-NSXTGroup fail

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.10'
+ModuleVersion = '1.0.11'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -791,7 +791,7 @@ Function Remove-NSXTFirewall {
                 Write-Host -ForegroundColor Red "`nThe NSX-T Proxy session is no longer valid, please re-run the Connect-NSXTProxy cmdlet to retrieve a new token`n"
                 break
             } else {
-                Write-Error "Error in creating new NSX-T Firewall Rule"
+                Write-Error "Error in removing NSX-T Firewall Rule"
                 Write-Error "`n($_.Exception.Message)`n"
                 break
             }
@@ -1077,7 +1077,7 @@ Function Remove-NSXTGroup {
                 Write-Host -ForegroundColor Red "`nThe NSX-T Proxy session is no longer valid, please re-run the Connect-NSXTProxy cmdlet to retrieve a new token`n"
                 break
             } else {
-                Write-Error "Error in creating new NSX-T Group"
+                Write-Error "Error in removing NSX-T Group"
                 Write-Error "`n($_.Exception.Message)`n"
                 break
             }


### PR DESCRIPTION
While executing Remove-NSXTFirewall or Remove-NSXTGroup and if it fails the host still writes "Error in creating new NSX-T Group/NSX-T Firewall Rule"

Signed-off-by: Mohamed Imthiyaz <mimthiyaz@vmware.com>