### PR TITLE
bug: Converted all API calls in Connect-NSXProxy to REST

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.11'
+ModuleVersion = '1.0.12'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Bypasses errors reported in com.vmware.vmc.org.sddcs.

Testing criteria:
Connect-NSXTProxy -RefreshToken $token -OrgName "InvalidOrgName" -SDDCName "ValidSDDCName"  - Error handled
Connect-NSXTProxy -RefreshToken $token -OrgName "ValidOrgName" -SDDCName "InvalidSDDCName" - Error handled
Connect-NSXTProxy -RefreshToken $token -OrgName "ValidOrgName" -SDDCName "ValidSDDCName" - Error handled

After successful connection
Get-NSXTSegment - succesful output

https://github.com/kremerpatrick/VMware.VMC.NSXT

Closes #10 

Signed-off-by: Patrick Kremer <pkremer@vmware.com>