### PR TITLE
fix: Replaces deprecated refresh_token in /authorize API

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.12'
+ModuleVersion = '1.0.13'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -26,7 +26,7 @@ Function Connect-NSXTProxy {
 
     If (-Not $global:DefaultVMCServers.IsConnected) { Write-error "No valid VMC Connection found, please use the Connect-VMC to connect"; break }
 
-    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -Headers @{accept='application/json'} -Body "refresh_token=$RefreshToken"
+    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -Headers @{accept='application/json'} -Body "api_token=$RefreshToken"
     if($results.StatusCode -ne 200) {
         Write-Host -ForegroundColor Red "Failed to retrieve Access Token, please ensure your VMC Refresh Token is valid and try again"
         break


### PR DESCRIPTION
Testing criteria:
Connect-NSXTProxy -RefreshToken $token -OrgName "ValidOrgName" -SDDCName "ValidSDDCName" 
-Connection Successful

After successful connection
Get-NSXTSegment - succesful output

Closes #12 
Signed-off-by: Patrick Kremer <pkremer@vmware.com>