### PR TITLE
Use vmc_internal_version for sddcVerson - fixes issue with Get-NSXTRouteTable

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.13'
+ModuleVersion = '1.0.14'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -91,7 +91,7 @@ Function Connect-NSXTProxy {
     $resultsJson = $results | ConvertFrom-Json
     if ($resultsJson.resource_config.nsxt) {
         $nsxtProxyURL = $resultsJson.resource_config.nsx_api_public_endpoint_url
-        $sddcVersion = (Get-VmcSddc -name $sddcname).version
+        $sddcVersion = $resultsJson.resource_config.sddc_manifest.vmc_internal_version
     } else {
         Write-Host -ForegroundColor Red "This is not an NSX-T based SDDC"
         break


### PR DESCRIPTION
The recent fix  #10 to use REST to query for certain SDDC info introduced an issue for `Get-NSXTRouteTable` - it is looking at the SDDC version number and expects it in dotted "internal" format. This PR uses the SDDC version from the new REST output instead of the friendly form that was coming from `Get-Vmc`.

**Before**

```
Connecting to NSX-T proxy...
sddcVersion : 1.15v2


> Get-NSXTRouteTable
InvalidArgument: /Users/egray/.local/share/powershell/Modules/VMware.VMC.NSXT/1.0.13/VMware.VMC.NSXT.psm1:1893
Line |
1893 |          if ([int]$global:nsxtProxyConnection.sddcVersion.split(".")[1 …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot convert value "15v2" to type "System.Int32". Error: "Input string was not in a correct format."

Get-NSXTRouteTable: Error in retrieving NSX-T Routing Table
Get-NSXTRouteTable:
(Cannot validate argument on parameter 'Uri'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again..Exception.Message)
```

**After**
```
sddcVersion : 1.15.0.12

> Get-NSXTRouteTable
Successfully retrieved NSX-T Routing Table
EdgeNode: /infra/sites/default/enforcement-points/vmc-enforcementpoint/edge-clusters/3e32eb69-8d36-4751-a6cd-4dcf7c8f9568/edge-nodes/0
Entries: 43

network                 next_hop        admin_distance route_type
-------                 --------        -------------- ----------
0.0.0.0/0               10.3.160.1                 200 T0 Static
10.100.0.0/21           10.3.168.1                   1 T0 Static
10.100.4.169/32                                      2 T0 NAT
...
```

Also tested with `sddcVersion : 1.14.0.10`