### PR TITLE
Update Get-NSXTServiceDefinition to display service names

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.15'
+ModuleVersion = '1.0.16'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.NSXT.psm1
+++ b/VMware.VMC.NSXT.psm1
@@ -1293,6 +1293,7 @@ Function Get-NSXTServiceDefinition {
                 $serviceProtocol = $serviceEntry.l4_protocol
                 $serviceSourcePorts = $serviceEntry.source_ports
                 $serviceDestinationPorts = $serviceEntry.destination_ports
+                $serviceNames = $serviceEntry.display_name
 
                 $tmp = [pscustomobject] @{
                     Name = $service.display_name;
@@ -1300,6 +1301,7 @@ Function Get-NSXTServiceDefinition {
                     Protocol = $serviceProtocol;
                     Source = $serviceSourcePorts;
                     Destination = $serviceDestinationPorts;
+                    Services = $serviceNames;
                     Path = $service.path;
                 }
                 $results += $tmp


### PR DESCRIPTION
When using `Get-NSXTServiceDefinition` I feel some data is missing on the returned output.  This PR will return the nested services within a service definition.

**Before**
```
PS /Users/ehill> Get-NSXTServiceDefinition "ICMP ALL"

Name        : ICMP ALL
Id          : ICMP-ALL
Protocol    :
Source      :
Destination :
Path        : /infra/services/ICMP-ALL
```

**After**
```
PS /Users/ehill> Get-NSXTServiceDefinition "ICMP ALL"

Name        : ICMP ALL
Id          : ICMP-ALL
Protocol    :
Source      :
Destination :
Services    : {ICMPv6-ALL, ICMPv4-ALL}
Path        : /infra/services/ICMP-ALL
```