### PR TITLE
Nested Services for New-NSXTServiceDefinition and Get-NSXTInfraScope Path Fix

### DIFF
--- a/VMware.VMC.NSXT.psd1
+++ b/VMware.VMC.NSXT.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.NSXT.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.16'
+ModuleVersion = '1.0.17'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Improvements to `New-NSXTServiceDefinition` to support nested services.

**Example**
```
PS /Users/ehill> New-NSXTServiceDefinition -Name "Ezra-MyHTTP2" -Service @("HTTP","HTTPS")
Successfully created new NSX-T Service Ezra-MyHTTP2

display_name id                                                                                                                                               ------------ --
Ezra-MyHTTP2 Ezra-MyHTTP2

PS /Users/ehill> Get-NSXTServiceDefinition -Name "Ezra-MyHTTP2"

Name        : Ezra-MyHTTP2
Id          : Ezra-MyHTTP2
Protocol    :
Source      :
Destination :
Services    : {HTTP, HTTPS}
Path        : /infra/services/Ezra-MyHTTP2

```

Also, fixed a bug when running `Get-NSXTInfraScope`, the Path property was null

**Before**
```
PS /Users/ehill> Get-NSXTInfraScope

Name                     Id                 Path
----                     --                 ----
All Uplinks              cgw-all
Direct Connect Interface cgw-direct-connect
Internet Interface       cgw-public
MGW                      mgw
VPC Interface            cgw-cross-vpc
VPN Tunnel Interface     cgw-vpn
```
**After**
```
PS /Users/ehill> Get-NSXTInfraScope
Name                     Id                 Path
----                     --                 ----
All Uplinks              cgw-all            /infra/labels/cgw-all
Direct Connect Interface cgw-direct-connect /infra/labels/cgw-direct-connect
Internet Interface       cgw-public         /infra/labels/cgw-public
MGW                      mgw                /infra/labels/mgw
VPC Interface            cgw-cross-vpc      /infra/labels/cgw-cross-vpc
VPN Tunnel Interface     cgw-vpn            /infra/labels/cgw-vpn
```